### PR TITLE
Allow for labels to be on their own lines

### DIFF
--- a/src/Language/Robo/Parser.purs
+++ b/src/Language/Robo/Parser.purs
@@ -22,11 +22,17 @@ import Language.Robo.Spec
 space :: Parser Unit
 space = void (string " " <|> string "\t")
 
-skipWhite :: Parser Unit
-skipWhite = void (many space)
-
 newline :: Parser Unit
 newline = void (char '\n' <|> char '\r')
+
+whitespace :: Parser Unit
+whitespace = space <|> newline
+
+skipSpace :: Parser Unit
+skipSpace = void (many space)
+
+skipWhite :: Parser Unit
+skipWhite = void (many whitespace)
 
 parseInstruction :: Parser Instruction
 parseInstruction =
@@ -66,7 +72,7 @@ parseLInstruction =
     pure $ LInstruction label instr
 
 separator :: Parser Unit
-separator = void (skipWhite *> newline *> many (newline <|> space))
+separator = void (skipSpace *> newline *> many (newline <|> space))
 
 parseProgram :: Parser Program
 parseProgram = sepBy parseLInstruction separator <* eof


### PR DESCRIPTION
Rename `skipWhite` to `skipSpace` and create a new function `skipWhite` that refers to both spaces and newlines. Use `skipWhite` in the definition of `parseLabel` and `skipSpace` in the definition of `separator`. Fixes #1.
